### PR TITLE
Add new Ethan Allen Express stops

### DIFF
--- a/us/ethan-allen-express.csv
+++ b/us/ethan-allen-express.csv
@@ -1,0 +1,4 @@
+﻿name,latitude,longitude
+"Burlington, Vermont",44.475709,-73.219577
+Ferrisburgh–Vergennes,44.1809,-73.2489
+Middlebury,44.0177,-73.1698


### PR DESCRIPTION
The Ethan Allen Express extension to Burlington has opened so there are three new stops.