### PR TITLE
Add Nashville stations

### DIFF
--- a/us/music-city-star.csv
+++ b/us/music-city-star.csv
@@ -1,0 +1,8 @@
+stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
+MCSDONEL,MCSDONEL,Donelson,NASHVILLE & EASTERN RR,36.167003,-86.666539,,,,,,0
+MCSHAM,MCSHAM,Hamilton Springs,,36.234559,-86.367777,,,,,,0
+MCSHERM,MCSHERM,Hermitage,,36.190234,-86.605609,,,,,,0
+MCSLB,MCSLB,Lebanon,,36.212085,-86.29724,,,,,,
+MCSMJ,MCSMJ,Mt. Juliet,,36.199384,-86.517,,,,,,0
+MCSMS,MCSMS,Martha,,36.228922,-86.425777,,,,,,0
+MCSRVRF,MCSRVRF,Riverfront,,36.161803,-86.773763,,,,,,


### PR DESCRIPTION
Nashville's Music City Star. Extracted from Nashville MTA GTFS feed; names title cased.